### PR TITLE
add `extensionKind` to the `package.json` make it work on SSH/WSL environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"logitech-craft-plugin": "^1.1.1",
 		"ws": "^7.2.5"
 	},
+	"extensionKind": "ui",
 	"categories": [
 		"Keymaps",
 		"Other"


### PR DESCRIPTION
This closes #30.

This will make sure your extension runs on primary VSCode instance rather than installed remotely. This will make sure Options can see VSCode and vice-versa.

P.S.: Tested.